### PR TITLE
Add password reset screen

### DIFF
--- a/todolist/src/App.tsx
+++ b/todolist/src/App.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Login from "./Pages/Login/Login";
 import Signup from "./Pages/Signup/Signup";
+import ResetPassword from "./Pages/ResetPassword/ResetPassword";
 import IssueRegister from "./Pages/IssueRegister/IssueRegister";
 import IssueEdit from "./Pages/IssueEdit/IssueEdit";
 import ProjectListPage from "./Pages/ProjectListPage/ProjectListPage";
@@ -22,6 +23,10 @@ function App() {
           element={user ? <Navigate to="/projects" /> : <Login />}
         />
         <Route path="/signup" element={<Signup />} />
+        <Route
+          path="/reset-password"
+          element={user ? <Navigate to="/projects" /> : <ResetPassword />}
+        />
         <Route
           path="/projects"
           element={user ? <ProjectListPage /> : <Navigate to="/" />}

--- a/todolist/src/Pages/Login/Login.tsx
+++ b/todolist/src/Pages/Login/Login.tsx
@@ -53,6 +53,7 @@ function Login() {
         />
         <Button onClick={handleLogin}>로그인</Button>
         <SubButton onClick={() => navigate("/signup")}>회원가입</SubButton>
+        <SubButton onClick={() => navigate("/reset-password")}>비밀번호 재설정</SubButton>
       </LoginBox>
     </Container>
   );

--- a/todolist/src/Pages/ResetPassword/ResetPassword.tsx
+++ b/todolist/src/Pages/ResetPassword/ResetPassword.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { sendPasswordResetEmail } from "firebase/auth";
+import { auth } from "../../Firebase/firebase";
+import {
+  Container,
+  LoginBox,
+  Input,
+  Button,
+  SubButton,
+  LogoSection,
+  ServiceName,
+  SubTitle,
+} from "../Login/Login.styled";
+
+function ResetPassword() {
+  const [email, setEmail] = useState("");
+  const navigate = useNavigate();
+
+  const handleReset = async () => {
+    if (!email) {
+      alert("이메일을 입력해주세요.");
+      return;
+    }
+
+    try {
+      await sendPasswordResetEmail(auth, email);
+      alert("비밀번호 재설정 이메일을 전송했습니다.");
+      navigate("/");
+    } catch (error) {
+      alert("비밀번호 재설정에 실패했습니다.");
+    }
+  };
+
+  return (
+    <Container>
+      <LoginBox>
+        <LogoSection>
+          <ServiceName>TIMS</ServiceName>
+          <SubTitle>비밀번호 재설정을 위해 이메일을 입력하세요</SubTitle>
+        </LogoSection>
+        <Input
+          type="email"
+          placeholder="이메일"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <Button onClick={handleReset}>재설정 메일 보내기</Button>
+        <SubButton onClick={() => navigate("/")}>로그인으로 돌아가기</SubButton>
+      </LoginBox>
+    </Container>
+  );
+}
+
+export default ResetPassword;


### PR DESCRIPTION
## Summary
- add `ResetPassword` page for Firebase password reset
- hook up reset password route in `App.tsx`
- link from login page to the reset password screen

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ca17fa3883268686160b0e25b4a0