### PR TITLE
Add password reset screen

### DIFF
--- a/todolist/src/App.tsx
+++ b/todolist/src/App.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Login from "./Pages/Login/Login";
 import Signup from "./Pages/Signup/Signup";
+import ResetPassword from "./Pages/ResetPassword/ResetPassword";
 import IssueRegister from "./Pages/IssueRegister/IssueRegister";
 import IssueEdit from "./Pages/IssueEdit/IssueEdit";
 import ProjectListPage from "./Pages/ProjectListPage/ProjectListPage";
@@ -22,6 +23,7 @@ function App() {
           element={user ? <Navigate to="/projects" /> : <Login />}
         />
         <Route path="/signup" element={<Signup />} />
+        <Route path="/reset-password" element={<ResetPassword />} />
         <Route
           path="/projects"
           element={user ? <ProjectListPage /> : <Navigate to="/" />}

--- a/todolist/src/Pages/ResetPassword/ResetPassword.tsx
+++ b/todolist/src/Pages/ResetPassword/ResetPassword.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { sendPasswordResetEmail } from "firebase/auth";
+import { auth } from "../../Firebase/firebase";
+import {
+  Container,
+  LoginBox,
+  Input,
+  Button,
+  SubButton,
+  LogoSection,
+  ServiceName,
+  SubTitle,
+} from "../Login/Login.styled";
+
+function ResetPassword() {
+  const [email, setEmail] = useState("");
+  const navigate = useNavigate();
+
+  const handleReset = async () => {
+    if (!email) {
+      alert("이메일을 입력해주세요.");
+      return;
+    }
+
+    try {
+      await sendPasswordResetEmail(auth, email);
+      alert("비밀번호 재설정 이메일을 발송했습니다.");
+      navigate("/");
+    } catch (error) {
+      alert("이메일 전송에 실패했습니다. 다시 시도해주세요.");
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      handleReset();
+    }
+  };
+
+  return (
+    <Container>
+      <LoginBox>
+        <LogoSection>
+          <ServiceName>TIMS</ServiceName>
+          <SubTitle>비밀번호 재설정</SubTitle>
+        </LogoSection>
+        <Input
+          type="email"
+          placeholder="이메일"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        <Button onClick={handleReset}>이메일 발송</Button>
+        <SubButton onClick={() => navigate("/")}>로그인으로 돌아가기</SubButton>
+      </LoginBox>
+    </Container>
+  );
+}
+
+export default ResetPassword;


### PR DESCRIPTION
## Summary
- add a ResetPassword screen under `Pages`
- wire password reset route into the main router

## Testing
- `npm test -- -w=0 --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d21dc8748326aaea5cf9fc5dd30e