### PR TITLE
Add UI improvements for project list

### DIFF
--- a/todolist/src/Pages/ProjectListPage/ProjectList.styled.tsx
+++ b/todolist/src/Pages/ProjectListPage/ProjectList.styled.tsx
@@ -19,6 +19,15 @@ export const ProjectList = styled.ul`
   margin-top: 12px;
 `;
 
+export const CardGrid = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin-top: 12px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px;
+`;
+
 export const InputRow = styled.div`
   display: flex;
   flex-wrap: wrap;
@@ -83,7 +92,7 @@ export const ProjectItem = styled.li`
   border-radius: 8px;
   margin-bottom: 10px;
   font-size: 16px;
-  transition: background-color 0.2s ease;
+  transition: background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 
   span {
     cursor: pointer;
@@ -96,6 +105,27 @@ export const ProjectItem = styled.li`
 
   &:hover {
     background-color: #3b3e7a;
+    transform: scale(1.02);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  }
+`;
+
+export const CardItem = styled.li`
+  padding: 12px;
+  background-color: #2c2f65;
+  border: 1px solid #3a3d70;
+  border-radius: 8px;
+  font-size: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transition: background-color 0.2s ease, transform 0.2s ease,
+    box-shadow 0.2s ease;
+
+  &:hover {
+    background-color: #3b3e7a;
+    transform: scale(1.02);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
   }
 `;
 
@@ -129,6 +159,15 @@ export const PinButton = styled.button`
   &:hover {
     transform: scale(1.1);
   }
+`;
+
+export const RecentBadge = styled.span`
+  background-color: #ff9800;
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+  margin-left: 8px;
 `;
 
 export const EditInput = styled.input`
@@ -180,4 +219,24 @@ export const StyledLogoutButton = styled.button`
   &:hover {
     background-color: #d9363e;
   }
+`;
+
+export const ViewToggleButton = styled.button`
+  padding: 8px 12px;
+  background-color: #4dabf7;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #339af0;
+  }
+`;
+
+export const ErrorMessage = styled.p`
+  color: #ff6b6b;
+  margin: 0 0 8px 0;
+  font-size: 14px;
 `;

--- a/todolist/src/Pages/ProjectListPage/ProjectListPage.tsx
+++ b/todolist/src/Pages/ProjectListPage/ProjectListPage.tsx
@@ -15,6 +15,9 @@ import {
   Title,
   ProjectList,
   ProjectItem,
+  CardGrid,
+  CardItem,
+  RecentBadge,
   InputRow,
   ProjectInput,
   AddButton,
@@ -24,6 +27,8 @@ import {
   DescriptionInput,
   EditInput,
   StyledLogoutButton,
+  ViewToggleButton,
+  ErrorMessage,
 } from "./ProjectList.styled";
 import { db, auth } from "../../Firebase/firebase";
 import { signOut } from "firebase/auth";
@@ -44,6 +49,7 @@ interface Project {
   isPinned?: boolean;
   isDeleted?: boolean;
   lastViewedAt?: string;
+  order?: number;
 }
 
 const ProjectListPage = () => {
@@ -55,6 +61,10 @@ const ProjectListPage = () => {
   const [editingDescription, setEditingDescription] = useState("");
   const [showTrash, setShowTrash] = useState(false);
   const [search, setSearch] = useState("");
+  const [recentProjectId, setRecentProjectId] = useState<string | null>(null);
+  const [draggedId, setDraggedId] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<'list' | 'card'>('list');
+  const [errorMessage, setErrorMessage] = useState<string>("");
   const navigate = useNavigate();
 
   const handleSignOut = async () => {
@@ -81,7 +91,8 @@ const ProjectListPage = () => {
           isPinned: data.isPinned || false,
           isDeleted: data.isDeleted || false,
           lastViewedAt: data.lastViewedAt || null,
-        };
+          order: data.order ?? 0,
+        } as Project;
       })
     );
 
@@ -90,10 +101,22 @@ const ProjectListPage = () => {
     const sorted = filtered.sort((a, b) => {
       if (a.isPinned && !b.isPinned) return -1;
       if (!a.isPinned && b.isPinned) return 1;
+      if (a.order !== undefined && b.order !== undefined) {
+        return a.order - b.order;
+      }
       const aTime = a.lastViewedAt ? new Date(a.lastViewedAt).getTime() : 0;
       const bTime = b.lastViewedAt ? new Date(b.lastViewedAt).getTime() : 0;
       return bTime - aTime;
     });
+
+    const mostRecent = filtered.reduce<Project | null>((prev, cur) => {
+      if (!prev) return cur;
+      const prevTime = prev.lastViewedAt ? new Date(prev.lastViewedAt).getTime() : 0;
+      const curTime = cur.lastViewedAt ? new Date(cur.lastViewedAt).getTime() : 0;
+      return curTime > prevTime ? cur : prev;
+    }, null);
+
+    setRecentProjectId(mostRecent ? mostRecent.id : null);
 
     setProjects(sorted);
   };
@@ -110,27 +133,43 @@ const ProjectListPage = () => {
 
   const confirmEdit = async () => {
     if (!editingId) return;
+    if (projects.some((p) => p.id !== editingId && p.name === editingName.trim())) {
+      setErrorMessage("동일한 이름의 프로젝트가 이미 존재합니다.");
+      return;
+    }
     await updateDoc(doc(db, "projects", editingId), {
       name: editingName,
       description: editingDescription,
     });
+    setErrorMessage("");
     setEditingId(null);
     fetchProjects();
   };
 
   const cancelEdit = () => {
     setEditingId(null);
+    setErrorMessage("");
   };
 
   const addProject = async () => {
     if (!newProjectName.trim()) return;
+    if (projects.some((p) => p.name === newProjectName.trim())) {
+      setErrorMessage("동일한 이름의 프로젝트가 이미 존재합니다.");
+      return;
+    }
+    const maxOrder = projects.reduce(
+      (max, p) => Math.max(max, p.order ?? 0),
+      -1
+    );
     await addDoc(collection(db, "projects"), {
       name: newProjectName.trim(),
       description: newDescription.trim(),
       isPinned: false,
       isDeleted: false,
       lastViewedAt: new Date().toISOString(),
+      order: maxOrder + 1,
     });
+    setErrorMessage("");
     setNewProjectName("");
     setNewDescription("");
     fetchProjects();
@@ -168,6 +207,34 @@ const ProjectListPage = () => {
     fetchProjects();
   };
 
+  const saveProjectOrder = async (list: Project[]) => {
+    await Promise.all(
+      list.map((p, index) => updateDoc(doc(db, "projects", p.id), { order: index }))
+    );
+  };
+
+  const handleDragStart = (id: string) => {
+    setDraggedId(id);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLLIElement>) => {
+    e.preventDefault();
+  };
+
+  const handleDrop = (id: string) => {
+    if (!draggedId || draggedId === id) return;
+    const dragItem = projects.find((p) => p.id === draggedId);
+    const dropIndex = projects.findIndex((p) => p.id === id);
+    const dragIndex = projects.findIndex((p) => p.id === draggedId);
+    if (!dragItem || dragItem.isPinned || projects[dropIndex].isPinned) return;
+    const newList = [...projects];
+    newList.splice(dragIndex, 1);
+    newList.splice(dropIndex, 0, dragItem);
+    setProjects(newList);
+    saveProjectOrder(newList);
+    setDraggedId(null);
+  };
+
   const filteredProjects = projects.filter((project) =>
     project.name.toLowerCase().includes(search.toLowerCase())
   );
@@ -187,9 +254,16 @@ const ProjectListPage = () => {
             ({filteredProjects.length}개)
           </span>
         </Title>
-        <StyledLogoutButton onClick={handleSignOut}>
-          로그아웃
-        </StyledLogoutButton>
+        <div style={{ display: "flex", gap: "8px" }}>
+          <ViewToggleButton
+            onClick={() =>
+              setViewMode((prev) => (prev === "list" ? "card" : "list"))
+            }
+          >
+            {viewMode === "list" ? "카드형" : "리스트형"}
+          </ViewToggleButton>
+          <StyledLogoutButton onClick={handleSignOut}>로그아웃</StyledLogoutButton>
+        </div>
       </div>
 
       <InputRow>
@@ -220,13 +294,22 @@ const ProjectListPage = () => {
         <AddButton onClick={addProject}>+ 추가</AddButton>
       </InputRow>
 
-      <ProjectList>
-        {filteredProjects.map((project) => (
-          <ProjectItem key={project.id}>
-            {editingId === project.id ? (
-              <div>
-                <EditInput
-                  value={editingName}
+      {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+
+      {viewMode === "list" ? (
+        <ProjectList>
+          {filteredProjects.map((project) => (
+            <ProjectItem
+              key={project.id}
+              draggable={!project.isPinned}
+              onDragStart={() => handleDragStart(project.id)}
+              onDragOver={handleDragOver}
+              onDrop={() => handleDrop(project.id)}
+            >
+              {editingId === project.id ? (
+                <div>
+                  <EditInput
+                    value={editingName}
                   onChange={(e) => setEditingName(e.target.value)}
                 />
                 <EditInput
@@ -250,6 +333,9 @@ const ProjectListPage = () => {
                 }}
               >
                 {project.name}
+                {project.id === recentProjectId && (
+                  <RecentBadge>최근 본 프로젝트</RecentBadge>
+                )}
                 <span style={{ marginLeft: 8, fontSize: 14, color: "#ccc" }}>
                   ({project.issueCount ?? 0}건)
                 </span>
@@ -293,7 +379,92 @@ const ProjectListPage = () => {
             </ActionGroup>
           </ProjectItem>
         ))}
-      </ProjectList>
+        </ProjectList>
+      ) : (
+        <CardGrid>
+          {filteredProjects.map((project) => (
+            <CardItem
+              key={project.id}
+              draggable={!project.isPinned}
+              onDragStart={() => handleDragStart(project.id)}
+              onDragOver={handleDragOver}
+              onDrop={() => handleDrop(project.id)}
+            >
+              {editingId === project.id ? (
+                <div>
+                  <EditInput
+                    value={editingName}
+                    onChange={(e) => setEditingName(e.target.value)}
+                  />
+                  <EditInput
+                    value={editingDescription}
+                    onChange={(e) => setEditingDescription(e.target.value)}
+                  />
+                  <PinButton onClick={confirmEdit}>
+                    <Check size={18} />
+                  </PinButton>
+                  <PinButton onClick={cancelEdit}>
+                    <XCircle size={18} />
+                  </PinButton>
+                </div>
+              ) : (
+                <span
+                  onClick={async () => {
+                    await updateDoc(doc(db, "projects", project.id), {
+                      lastViewedAt: new Date().toISOString(),
+                    });
+                    navigate(`/projects/${project.id}/issues`);
+                  }}
+                >
+                  {project.name}
+                  {project.id === recentProjectId && (
+                    <RecentBadge>최근 본 프로젝트</RecentBadge>
+                  )}
+                  <span style={{ marginLeft: 8, fontSize: 14, color: "#ccc" }}>
+                    ({project.issueCount ?? 0}건)
+                  </span>
+                  {project.description && (
+                    <div style={{ fontSize: 12, color: "#aaa" }}>
+                      {project.description}
+                    </div>
+                  )}
+                </span>
+              )}
+
+              <ActionGroup>
+                {!showTrash && editingId !== project.id && (
+                  <PinButton onClick={() => startEdit(project)}>
+                    <Edit3 size={18} />
+                  </PinButton>
+                )}
+                {!showTrash && (
+                  <PinButton
+                    onClick={() =>
+                      togglePin(project.id, project.isPinned ?? false)
+                    }
+                  >
+                    {project.isPinned ? <PinOff size={20} /> : <Pin size={20} />}
+                  </PinButton>
+                )}
+                {showTrash ? (
+                  <>
+                    <PinButton onClick={() => restoreProject(project.id)}>
+                      <Undo2 size={20} />
+                    </PinButton>
+                    <DeleteButton onClick={() => permanentlyDelete(project.id)}>
+                      <XCircle size={20} />
+                    </DeleteButton>
+                  </>
+                ) : (
+                  <DeleteButton onClick={() => softDeleteProject(project.id)}>
+                    <Trash2 size={20} />
+                  </DeleteButton>
+                )}
+              </ActionGroup>
+            </CardItem>
+          ))}
+        </CardGrid>
+      )}
     </Container>
   );
 };


### PR DESCRIPTION
## Summary
- add card grid styles and toggle button
- keep project order in Firestore when dragging
- show duplicate project name errors inline
- allow switching between list and card views

## Testing
- `npm test -- -w 0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844503607f08326aa22ecd24a3611c4