### PR TITLE
Add project completion progress

### DIFF
--- a/todolist/src/Pages/ProjectListPage/ProjectEditFields.tsx
+++ b/todolist/src/Pages/ProjectListPage/ProjectEditFields.tsx
@@ -27,11 +27,6 @@ const ProjectEditFields: React.FC<ProjectEditFieldsProps> = ({
         <Check size={18} />
       </PinButton>
       <PinButton aria-label="cancel" onClick={onCancel}>
-=======
-      <PinButton onClick={onConfirm}>
-        <Check size={18} />
-      </PinButton>
-      <PinButton onClick={onCancel}>
         <XCircle size={18} />
       </PinButton>
     </div>

--- a/todolist/src/Pages/ProjectListPage/ProjectList.styled.tsx
+++ b/todolist/src/Pages/ProjectListPage/ProjectList.styled.tsx
@@ -215,6 +215,24 @@ export const RecentBadge = styled.span`
   margin-left: 8px;
 `;
 
+export const ProgressWrapper = styled.div`
+  width: 100%;
+`;
+
+export const ProgressBackground = styled.div`
+  width: 100%;
+  background-color: ${({ theme }) => theme.colors.inputBorder};
+  height: 6px;
+  border-radius: 4px;
+  overflow: hidden;
+`;
+
+export const ProgressBar = styled.div<{ percent: number }>`
+  height: 6px;
+  background-color: ${({ theme }) => theme.colors.primary};
+  width: ${(props) => props.percent}%;
+`;
+
 export const EditInput = styled.input`
   padding: 8px;
   font-size: 14px;

--- a/todolist/src/Pages/ProjectListPage/ProjectListPage.tsx
+++ b/todolist/src/Pages/ProjectListPage/ProjectListPage.tsx
@@ -33,6 +33,9 @@ import {
   ViewToggleButton,
   ErrorMessage,
   PinnedBar,
+  ProgressWrapper,
+  ProgressBackground,
+  ProgressBar,
 } from "./ProjectList.styled";
 import ProjectEditFields from "./ProjectEditFields";
 import { db, auth } from "../../Firebase/firebase";
@@ -58,6 +61,7 @@ interface Project {
   isArchived?: boolean;
   lastViewedAt?: string;
   order?: number;
+  completionRate?: number;
 }
 
 const ProjectListPage = () => {
@@ -100,10 +104,22 @@ const ProjectListPage = () => {
         const issueSnapshot = await getDocs(q);
         const issueCount = issueSnapshot.size;
 
+        const finishedSnapshot = await getDocs(
+          query(
+            collection(db, "issues"),
+            where("projectId", "==", projectId),
+            where("status", "==", "완료")
+          )
+        );
+        const finishedCount = finishedSnapshot.size;
+        const completionRate =
+          issueCount > 0 ? Math.round((finishedCount / issueCount) * 100) : 0;
+
         return {
           id: projectId,
           ...(data as any),
           issueCount,
+          completionRate,
           isPinned: data.isPinned || false,
           isDeleted: data.isDeleted || false,
           isArchived: data.isArchived || false,
@@ -399,6 +415,11 @@ const ProjectListPage = () => {
                   <span style={{ marginLeft: 8, fontSize: 14, color: "#ccc" }}>
                     ({project.issueCount ?? 0}건)
                   </span>
+                  <ProgressWrapper>
+                    <ProgressBackground>
+                      <ProgressBar percent={project.completionRate ?? 0} />
+                    </ProgressBackground>
+                  </ProgressWrapper>
                   {project.description && (
                     <div style={{ fontSize: 12, color: "#aaa" }}>
                       {project.description}
@@ -492,6 +513,11 @@ const ProjectListPage = () => {
                   <span style={{ marginLeft: 8, fontSize: 14, color: "#ccc" }}>
                     ({project.issueCount ?? 0}건)
                   </span>
+                  <ProgressWrapper>
+                    <ProgressBackground>
+                      <ProgressBar percent={project.completionRate ?? 0} />
+                    </ProgressBackground>
+                  </ProgressWrapper>
                   {project.description && (
                     <div style={{ fontSize: 12, color: "#aaa" }}>
                       {project.description}


### PR DESCRIPTION
## Summary
- fetch completed issue count to calculate project completion rate
- add progress bar components
- render progress indicators on project list and card views
- clean up ProjectEditFields markup

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae9f78aac83269e622bb37620ab3c