### PR TITLE
Implement share UI using Firebase users

### DIFF
--- a/todolist/src/Pages/Login/Login.tsx
+++ b/todolist/src/Pages/Login/Login.tsx
@@ -8,7 +8,8 @@ import {
   browserSessionPersistence,
   GoogleAuthProvider,
 } from "firebase/auth";
-import { auth } from "../../Firebase/firebase";
+import { auth, db } from "../../Firebase/firebase";
+import { setDoc, doc, getDoc } from "firebase/firestore";
 import {
   Container,
   LoginBox,
@@ -81,7 +82,14 @@ function Login() {
         auth,
         keepLoggedIn ? browserLocalPersistence : browserSessionPersistence
       );
-      await signInWithEmailAndPassword(auth, email, password);
+      const cred = await signInWithEmailAndPassword(auth, email, password);
+      const userDoc = await getDoc(doc(db, "users", cred.user.uid));
+      if (!userDoc.exists()) {
+        await setDoc(doc(db, "users", cred.user.uid), {
+          uid: cred.user.uid,
+          email: cred.user.email,
+        });
+      }
       navigate("/projects");
     } catch (error: any) {
       switch (error.code) {
@@ -119,7 +127,14 @@ function Login() {
     try {
       setErrorMessage("");
       const provider = new GoogleAuthProvider();
-      await signInWithPopup(auth, provider);
+      const cred = await signInWithPopup(auth, provider);
+      const userDoc = await getDoc(doc(db, "users", cred.user.uid));
+      if (!userDoc.exists()) {
+        await setDoc(doc(db, "users", cred.user.uid), {
+          uid: cred.user.uid,
+          email: cred.user.email,
+        });
+      }
       navigate("/projects");
     } catch (err) {
       showError("SNS 로그인 실패");

--- a/todolist/src/Pages/ProjectListPage/ProjectShareModal.styled.tsx
+++ b/todolist/src/Pages/ProjectListPage/ProjectShareModal.styled.tsx
@@ -1,0 +1,60 @@
+import styled, { keyframes } from "styled-components";
+
+const fadeIn = keyframes`
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+`;
+
+export const Backdrop = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+`;
+
+export const Modal = styled.div`
+  background: #1e1f2f;
+  color: #ffffff;
+  padding: 24px;
+  border-radius: 12px;
+  width: 320px;
+  animation: ${fadeIn} 0.25s ease-out;
+`;
+
+export const Select = styled.select`
+  width: 100%;
+  padding: 8px 10px;
+  margin-bottom: 16px;
+  background: #2a2e5b;
+  border: 1px solid #444c77;
+  color: #fff;
+  border-radius: 6px;
+`;
+
+export const ButtonGroup = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+`;
+
+export const Button = styled.button`
+  padding: 8px 12px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  color: #fff;
+`;
+
+export const AddButton = styled(Button)`
+  background: #4fa94d;
+`;
+
+export const CancelButton = styled(Button)`
+  background: #6c6f7b;
+`;

--- a/todolist/src/Pages/ProjectListPage/ProjectShareModal.tsx
+++ b/todolist/src/Pages/ProjectListPage/ProjectShareModal.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from "react";
+import { Backdrop, Modal, Select, ButtonGroup, AddButton, CancelButton } from "./ProjectShareModal.styled";
+
+interface User {
+  uid: string;
+  email: string | null;
+}
+
+interface Props {
+  users: User[];
+  onAdd: (uid: string) => void;
+  onClose: () => void;
+}
+
+export default function ProjectShareModal({ users, onAdd, onClose }: Props) {
+  const [selected, setSelected] = useState<string>("");
+
+  return (
+    <Backdrop>
+      <Modal>
+        <Select value={selected} onChange={(e) => setSelected(e.target.value)}>
+          <option value="" disabled>
+            사용자 선택
+          </option>
+          {users.map((u) => (
+            <option key={u.uid} value={u.uid}>
+              {u.email}
+            </option>
+          ))}
+        </Select>
+        <ButtonGroup>
+          <CancelButton onClick={onClose}>취소</CancelButton>
+          <AddButton onClick={() => selected && onAdd(selected)}>추가</AddButton>
+        </ButtonGroup>
+      </Modal>
+    </Backdrop>
+  );
+}

--- a/todolist/src/Pages/Signup/Signup.tsx
+++ b/todolist/src/Pages/Signup/Signup.tsx
@@ -3,7 +3,8 @@ import {
   createUserWithEmailAndPassword,
   fetchSignInMethodsForEmail,
 } from "firebase/auth";
-import { auth } from "../../Firebase/firebase";
+import { auth, db } from "../../Firebase/firebase";
+import { setDoc, doc } from "firebase/firestore";
 import {
   Container,
   SignupBox,
@@ -106,7 +107,11 @@ function Signup() {
     }
 
     try {
-      await createUserWithEmailAndPassword(auth, email, password);
+      const cred = await createUserWithEmailAndPassword(auth, email, password);
+      await setDoc(doc(db, "users", cred.user.uid), {
+        uid: cred.user.uid,
+        email: cred.user.email,
+      });
       alert("회원가입 성공!");
       navigate("/");
     } catch {


### PR DESCRIPTION
## Summary
- save signup users to Firestore `users` collection
- ensure user documents exist on login
- add modal for sharing projects with other users
- list users in dropdown when sharing a project

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*
- `npx tsc -p tsconfig.json` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684cf8bcd6208326be84afb7faf7cfef