### PR TITLE
Show login account dropdown

### DIFF
--- a/todolist/src/Pages/Login/Login.styled.tsx
+++ b/todolist/src/Pages/Login/Login.styled.tsx
@@ -134,6 +134,22 @@ export const Input = styled.input`
   }
 `;
 
+export const AccountSelect = styled.select`
+  padding: 12px 14px;
+  margin-bottom: 16px;
+  border: 1px solid #444;
+  border-radius: 8px;
+  background-color: #1f1f3d;
+  color: white;
+  font-size: 15px;
+  width: 100%;
+  box-sizing: border-box;
+
+  &:focus {
+    outline: 2px solid #4fa94d;
+  }
+`;
+
 export const PasswordWrapper = styled.div`
   position: relative;
   width: 100%;

--- a/todolist/src/Pages/Login/Login.tsx
+++ b/todolist/src/Pages/Login/Login.tsx
@@ -9,7 +9,7 @@ import {
   GoogleAuthProvider,
 } from "firebase/auth";
 import { auth, db } from "../../Firebase/firebase";
-import { setDoc, doc, getDoc } from "firebase/firestore";
+import { setDoc, doc, getDoc, collection, getDocs } from "firebase/firestore";
 import {
   Container,
   LoginBox,
@@ -22,6 +22,7 @@ import {
   TogglePassword,
   PasswordWrapper,
   CheckboxLabel,
+  AccountSelect,
   SNSButton,
   SubButtonRow,
   ShakeWrapper,
@@ -38,6 +39,7 @@ function Login() {
   const [keepLoggedIn, setKeepLoggedIn] = useState(false);
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+  const [accountList, setAccountList] = useState<string[]>([]);
   const [shouldShake, setShouldShake] = useState(false);
   const emailRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
@@ -45,6 +47,21 @@ function Login() {
 
   useEffect(() => {
     emailRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const fetchAccounts = async () => {
+      try {
+        const snap = await getDocs(collection(db, "users"));
+        const emails = snap.docs
+          .map((d) => (d.data() as any).email as string | null)
+          .filter((e): e is string => !!e);
+        setAccountList(emails);
+      } catch {
+        // ignore errors
+      }
+    };
+    fetchAccounts();
   }, []);
 
   const triggerShake = () => {
@@ -161,6 +178,19 @@ function Login() {
             }
             autoComplete="email"
           />
+          {accountList.length > 0 && (
+            <AccountSelect
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            >
+              <option value="">계정 선택</option>
+              {accountList.map((mail) => (
+                <option key={mail} value={mail}>
+                  {mail}
+                </option>
+              ))}
+            </AccountSelect>
+          )}
 
           <PasswordWrapper>
             <Input


### PR DESCRIPTION
## Summary
- add `AccountSelect` styled component
- fetch user emails from Firestore in login page
- display an account dropdown on the login screen

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npx tsc --noEmit` *(fails: packages not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684d0c7194e883269d1f901de0b688f2