### PR TITLE
Add NotFound page

### DIFF
--- a/todolist/src/App.tsx
+++ b/todolist/src/App.tsx
@@ -8,6 +8,7 @@ import IssueEdit from "./Pages/IssueEdit/IssueEdit";
 import ProjectListPage from "./Pages/ProjectListPage/ProjectListPage";
 import IssueList from "./Pages/IssueList/IssueList";
 import MyPage from "./Pages/MyPage/MyPage"; // ✅ 추가
+import NotFound from "./Pages/NotFound/NotFound";
 import { auth } from "./Firebase/firebase";
 import { useAuthState } from "react-firebase-hooks/auth";
 
@@ -59,6 +60,7 @@ function App() {
           path="/mypage"
           element={user ? <MyPage /> : <Navigate to="/login" />}
         />
+        <Route path="*" element={<NotFound />} />
       </Routes>
     </BrowserRouter>
   );

--- a/todolist/src/Pages/NotFound/NotFound.styled.tsx
+++ b/todolist/src/Pages/NotFound/NotFound.styled.tsx
@@ -1,0 +1,25 @@
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background-color: ${({ theme }) => theme.colors.background};
+  color: #fff;
+`;
+
+export const Message = styled.h1`
+  font-size: 32px;
+  margin-bottom: 16px;
+`;
+
+export const StyledLink = styled(Link)`
+  color: ${({ theme }) => theme.colors.primary};
+  text-decoration: underline;
+  &:hover {
+    color: ${({ theme }) => theme.colors.primaryHover};
+  }
+`;

--- a/todolist/src/Pages/NotFound/NotFound.tsx
+++ b/todolist/src/Pages/NotFound/NotFound.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Container, Message, StyledLink } from "./NotFound.styled";
+
+function NotFound() {
+  return (
+    <Container>
+      <Message>Page Not Found</Message>
+      <StyledLink to="/projects">Go to Projects</StyledLink>
+    </Container>
+  );
+}
+
+export default NotFound;


### PR DESCRIPTION
## Summary
- display a "Page Not Found" screen on unknown routes
- include link back to the projects page
- register a catch-all route in the app router

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*
- `npx tsc -p tsconfig.json` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68713226b1508326ada6c567783c75ae