### PR TITLE
Show tags in issue detail modal

### DIFF
--- a/todolist/src/Pages/IssueList/IssueDetailModal.styled.tsx
+++ b/todolist/src/Pages/IssueList/IssueDetailModal.styled.tsx
@@ -246,3 +246,13 @@ export const CommentActionRow = styled.div`
     background: #868e96;
   }
 `;
+
+export const Tag = styled.div`
+  background-color: #5c7cfa;
+  color: white;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  font-size: 12px;
+  margin-top: 6px;
+  display: inline-block;
+`;

--- a/todolist/src/Pages/IssueList/IssueDetailModal.tsx
+++ b/todolist/src/Pages/IssueList/IssueDetailModal.tsx
@@ -17,6 +17,7 @@ import {
   CommentList,
   CommentItem,
   CommentActionRow,
+  Tag,
 } from "./IssueDetailModal.styled";
 import { db, auth } from "../../Firebase/firebase";
 import { doc, updateDoc, arrayUnion } from "firebase/firestore";
@@ -40,6 +41,7 @@ interface Issue {
   createdAt?: any;
   status?: string;
   comments?: Comment[];
+  tags?: string[];
 }
 
 interface Props {
@@ -59,6 +61,7 @@ export default function IssueDetailModal({
 }: Props) {
   const [status, setStatus] = useState(issue.status || "할 일");
   const [comments, setComments] = useState<Comment[]>(issue.comments || []);
+  const [tags, setTags] = useState<string[]>(issue.tags || []);
   const [comment, setComment] = useState("");
   const [editIndex, setEditIndex] = useState<number | null>(null);
   const [editText, setEditText] = useState("");
@@ -71,6 +74,10 @@ export default function IssueDetailModal({
     window.addEventListener("keydown", handleEsc);
     return () => window.removeEventListener("keydown", handleEsc);
   }, [onClose]);
+
+  useEffect(() => {
+    setTags(issue.tags || []);
+  }, [issue.tags]);
 
   const formatDate = (timestamp: any) => {
     if (!timestamp?.toDate) return "-";
@@ -159,6 +166,16 @@ export default function IssueDetailModal({
         <Field>
           <span>우선순위:</span> {issue.priority}
         </Field>
+        {tags.length > 0 && (
+          <Field>
+            <span>태그:</span>
+            <div>
+              {tags.map((tag, idx) => (
+                <Tag key={idx}>#{tag}</Tag>
+              ))}
+            </div>
+          </Field>
+        )}
         {issue.category && (
           <Field>
             <span>카테고리:</span> {issue.category}


### PR DESCRIPTION
## Summary
- render issue tags in IssueDetailModal
- update styles for tag rendering
- keep modal tags in sync with issue prop

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68719504f0dc83269715a0c42d8eaab6