### PR TITLE
refactor: move inline styles to styled components

### DIFF
--- a/todolist/src/Pages/ProjectListPage/ProjectList.styled.tsx
+++ b/todolist/src/Pages/ProjectListPage/ProjectList.styled.tsx
@@ -298,3 +298,23 @@ export const PinnedBar = styled.div`
   font-size: 14px;
   font-weight: bold;
 `;
+
+export const ProjectCount = styled.span`
+  font-size: 16px;
+  margin-left: 8px;
+  color: #aaa;
+`;
+
+export const LoadingMessage = styled.div`
+  text-align: center;
+  padding: 40px;
+  font-size: 18px;
+`;
+
+export const ProfileImage = styled.img`
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  cursor: pointer;
+  object-fit: cover;
+`;

--- a/todolist/src/Pages/ProjectListPage/ProjectListPage.tsx
+++ b/todolist/src/Pages/ProjectListPage/ProjectListPage.tsx
@@ -19,6 +19,9 @@ import {
   PinnedBar,
   HeaderRow,
   HeaderActions,
+  ProjectCount,
+  LoadingMessage,
+  ProfileImage,
 } from "./ProjectList.styled";
 import ProjectItemContent from "./ProjectItemContent";
 import { db, auth } from "../../Firebase/firebase";
@@ -76,17 +79,10 @@ const ProfileAvatar = ({ onClick }: { onClick: () => void }) => {
   }, []);
 
   return (
-    <img
+    <ProfileImage
       src={profileImage || "https://placekitten.com/200/200"}
       alt="프로필"
       onClick={onClick}
-      style={{
-        width: 36,
-        height: 36,
-        borderRadius: "50%",
-        cursor: "pointer",
-        objectFit: "cover",
-      }}
     />
   );
 };
@@ -488,12 +484,10 @@ const ProjectListPage = () => {
   return (
     <Container>
       <HeaderRow>
-        <Title>
-          📁 프로젝트 목록{" "}
-          <span style={{ fontSize: "16px", marginLeft: "8px", color: "#aaa" }}>
-            ({filteredProjects.length}개)
-          </span>
-        </Title>
+          <Title>
+            📁 프로젝트 목록{" "}
+            <ProjectCount>({filteredProjects.length}개)</ProjectCount>
+          </Title>
         <HeaderActions>
           <ViewToggleButton onClick={toggleViewMode}>
             {viewMode === "list" ? "카드형" : "리스트형"}
@@ -542,11 +536,9 @@ const ProjectListPage = () => {
           고정: {pinnedProjects.map((p) => p.name).join(", ")}
         </PinnedBar>
       )}
-      {loading ? (
-        <div style={{ textAlign: "center", padding: "40px", fontSize: "18px" }}>
-          불러오는 중...
-        </div>
-      ) : viewMode === "list" ? (
+        {loading ? (
+          <LoadingMessage>불러오는 중...</LoadingMessage>
+        ) : viewMode === "list" ? (
         <ProjectList>
             {[...pinnedProjects, ...otherProjects].map((project) => (
               <ProjectItem


### PR DESCRIPTION
## Summary
- replace inline styles in ProjectListPage with styled components
- centralize avatar, count, and loading styles in ProjectList.styled.tsx

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68aaa721ce6083268b4285e942e9aec7