### PR TITLE
Align issue register theme with login

### DIFF
--- a/todolist/src/Pages/IssueRegister/IssueRegister.styled.tsx
+++ b/todolist/src/Pages/IssueRegister/IssueRegister.styled.tsx
@@ -19,16 +19,16 @@ export const RegisterContainer = styled.div`
   min-height: 100vh;
   align-items: center;
   padding: clamp(32px, 6vw, 72px) 16px 72px;
-  background: linear-gradient(135deg, #f4f7ff 0%, #efe8ff 45%, #fff4f4 100%);
-  color: #1f2937;
+  background: radial-gradient(circle at top, #2c2c54 0%, rgba(28, 28, 60, 0.9) 45%, #1c1c3c 100%);
+  color: #e2e8f0;
 `;
 
 export const RegisterBox = styled.div`
   position: relative;
-  background-color: #ffffff;
+  background-color: rgba(44, 44, 84, 0.96);
   padding: clamp(28px, 5vw, 40px);
   border-radius: 24px;
-  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 30px 80px rgba(4, 6, 28, 0.55);
   width: min(820px, 94vw);
   overflow: hidden;
 
@@ -43,7 +43,7 @@ export const IntroPanel = styled.section`
   padding: 26px clamp(22px, 4vw, 32px);
   margin-bottom: clamp(26px, 4vw, 34px);
   border-radius: 20px;
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(79, 70, 229, 0.92));
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(99, 102, 241, 0.88));
   color: #f8fafc;
   overflow: hidden;
 
@@ -132,14 +132,14 @@ export const HeaderTop = styled.div`
 export const RegisterTitle = styled.h1`
   font-size: clamp(26px, 5vw, 36px);
   font-weight: 700;
-  color: #0f172a;
+  color: #f8fafc;
   line-height: 1.3;
   margin: 0;
 `;
 
 export const RegisterSubtitle = styled.p`
   margin: 6px 0 0;
-  color: #6b7280;
+  color: #c7d2fe;
   font-size: 15px;
 `;
 
@@ -149,8 +149,8 @@ export const ProjectBadge = styled.span`
   gap: 8px;
   padding: 10px 16px;
   border-radius: 999px;
-  background: rgba(99, 102, 241, 0.12);
-  color: #4338ca;
+  background: rgba(99, 102, 241, 0.22);
+  color: #e0e7ff;
   font-weight: 600;
   font-size: 13px;
   letter-spacing: 0.01em;
@@ -162,8 +162,8 @@ export const MetaBar = styled.div`
   gap: 14px;
   padding: 18px;
   border-radius: 16px;
-  background: linear-gradient(135deg, rgba(99, 102, 241, 0.12), rgba(236, 72, 153, 0.1));
-  border: 1px solid rgba(99, 102, 241, 0.18);
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.22), rgba(236, 72, 153, 0.16));
+  border: 1px solid rgba(148, 163, 184, 0.22);
 `;
 
 export const MetaItem = styled.div`
@@ -176,13 +176,13 @@ export const MetaLabel = styled.span`
   font-size: 13px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #6b7280;
+  color: #cbd5f5;
 `;
 
 export const MetaValue = styled.span`
   font-size: 15px;
   font-weight: 600;
-  color: #1f2937;
+  color: #f8fafc;
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -206,8 +206,8 @@ export const CategoryBadge = styled.span`
   gap: 6px;
   padding: 6px 12px;
   border-radius: 999px;
-  background-color: rgba(79, 70, 229, 0.12);
-  color: #4338ca;
+  background-color: rgba(79, 70, 229, 0.25);
+  color: #ede9fe;
   font-weight: 600;
   font-size: 13px;
 `;
@@ -222,7 +222,7 @@ export const Form = styled.div`
 export const SectionTitle = styled.h2`
   margin: 0 0 12px;
   font-size: 18px;
-  color: #1f2937;
+  color: #f1f5f9;
   font-weight: 700;
 `;
 
@@ -241,13 +241,13 @@ export const FieldGroup = styled.div`
 export const FieldLabel = styled.label`
   font-size: 14px;
   font-weight: 600;
-  color: #475569;
+  color: #e2e8f0;
 `;
 
 export const FieldDescription = styled.p`
   margin: 0;
   font-size: 13px;
-  color: #94a3b8;
+  color: #cbd5f5;
 `;
 
 export const Input = styled.input`
@@ -255,24 +255,24 @@ export const Input = styled.input`
   padding: 0 16px;
   font-size: 15px;
   border-radius: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.5);
-  background-color: rgba(255, 255, 255, 0.9);
-  color: #0f172a;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background-color: rgba(31, 31, 61, 0.85);
+  color: #f8fafc;
   outline: none;
   transition: border 0.2s ease, box-shadow 0.2s ease;
 
   &:focus {
-    border-color: #6366f1;
-    box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.15);
+    border-color: #8b5cf6;
+    box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.2);
   }
 
   &:disabled {
-    background-color: rgba(241, 245, 249, 0.9);
-    color: #64748b;
+    background-color: rgba(51, 51, 89, 0.7);
+    color: #cbd5f5;
   }
 
   &::placeholder {
-    color: #9ca3af;
+    color: #94a3b8;
   }
 `;
 
@@ -281,9 +281,9 @@ export const TextArea = styled.textarea`
   padding: 16px;
   font-size: 15px;
   border-radius: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.5);
-  background-color: rgba(255, 255, 255, 0.92);
-  color: #0f172a;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background-color: rgba(31, 31, 61, 0.9);
+  color: #f8fafc;
   resize: vertical;
   outline: none;
   line-height: 1.6;
@@ -291,7 +291,7 @@ export const TextArea = styled.textarea`
 
   &:focus {
     border-color: #8b5cf6;
-    box-shadow: 0 0 0 4px rgba(139, 92, 246, 0.15);
+    box-shadow: 0 0 0 4px rgba(139, 92, 246, 0.2);
   }
 
   &::placeholder {
@@ -304,23 +304,23 @@ export const Select = styled.select`
   padding: 0 16px;
   font-size: 15px;
   border-radius: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.5);
-  background-color: rgba(255, 255, 255, 0.92);
-  color: #0f172a;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background-color: rgba(31, 31, 61, 0.85);
+  color: #f8fafc;
   cursor: pointer;
   outline: none;
   transition: border 0.2s ease, box-shadow 0.2s ease;
 
   &:focus {
     border-color: #6366f1;
-    box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.12);
+    box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.2);
   }
 `;
 
 export const Divider = styled.hr`
   margin: 8px 0 12px;
   border: none;
-  border-top: 1px dashed rgba(148, 163, 184, 0.4);
+  border-top: 1px dashed rgba(148, 163, 184, 0.35);
 `;
 
 export const TagWrapper = styled.div`
@@ -331,15 +331,15 @@ export const TagWrapper = styled.div`
 
 export const TagHint = styled.span`
   font-size: 13px;
-  color: #94a3b8;
+  color: #cbd5f5;
 `;
 
 export const TagInput = styled.input`
   padding: 12px 16px;
-  border: 1px dashed rgba(99, 102, 241, 0.5);
+  border: 1px dashed rgba(129, 140, 248, 0.6);
   border-radius: 12px;
-  background-color: rgba(248, 250, 252, 0.9);
-  color: #1f2937;
+  background-color: rgba(31, 31, 61, 0.85);
+  color: #f8fafc;
   font-size: 14px;
   outline: none;
   transition: border 0.2s ease, box-shadow 0.2s ease;
@@ -347,7 +347,7 @@ export const TagInput = styled.input`
   &:focus {
     border-style: solid;
     border-color: #8b5cf6;
-    box-shadow: 0 0 0 4px rgba(139, 92, 246, 0.12);
+    box-shadow: 0 0 0 4px rgba(139, 92, 246, 0.18);
   }
 
   &::placeholder {
@@ -368,8 +368,8 @@ export const TagList = styled.div`
 export const EmptyTag = styled.span`
   padding: 8px 12px;
   border-radius: 10px;
-  background-color: rgba(148, 163, 184, 0.16);
-  color: #64748b;
+  background-color: rgba(99, 102, 241, 0.2);
+  color: #e2e8f0;
   font-size: 13px;
 `;
 
@@ -421,7 +421,7 @@ export const FormFooter = styled.div`
 export const FooterNote = styled.p`
   margin: 0;
   font-size: 13px;
-  color: #94a3b8;
+  color: #cbd5f5;
 `;
 
 export const RegisterButton = styled.button`
@@ -448,17 +448,17 @@ export const RegisterButton = styled.button`
 export const CancelButton = styled.button`
   min-width: 110px;
   height: 44px;
-  background-color: rgba(15, 23, 42, 0.06);
-  color: #1f2937;
+  background-color: rgba(15, 23, 42, 0.35);
+  color: #e2e8f0;
   font-weight: 600;
   border-radius: 12px;
-  border: 1px solid rgba(15, 23, 42, 0.1);
+  border: 1px solid rgba(148, 163, 184, 0.25);
   cursor: pointer;
   transition: transform 0.2s ease, border 0.2s ease;
 
   &:hover {
     transform: translateY(-2px);
-    border-color: rgba(15, 23, 42, 0.25);
+    border-color: rgba(148, 163, 184, 0.4);
   }
 
   @media (max-width: 600px) {
@@ -467,13 +467,13 @@ export const CancelButton = styled.button`
 `;
 
 export const SuggestionBox = styled.ul`
-  background-color: white;
+  background-color: rgba(31, 31, 61, 0.98);
   border-radius: 12px;
   margin-top: 6px;
   padding: 6px 0;
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 18px 40px rgba(4, 6, 28, 0.35);
   list-style: none;
-  color: #222;
+  color: #e2e8f0;
   max-height: 180px;
   overflow-y: auto;
 `;
@@ -485,7 +485,7 @@ export const SuggestionItem = styled.li`
   transition: background-color 0.2s ease;
 
   &:hover {
-    background-color: rgba(99, 102, 241, 0.08);
+    background-color: rgba(99, 102, 241, 0.22);
   }
 `;
 

--- a/todolist/src/Pages/IssueRegister/IssueRegister.tsx
+++ b/todolist/src/Pages/IssueRegister/IssueRegister.tsx
@@ -87,10 +87,12 @@ function IssueRegister() {
   const customSelectStyles = {
     control: (provided: any, state: any) => ({
       ...provided,
-      backgroundColor: "rgba(248, 250, 252, 0.9)",
-      borderColor: state.isFocused ? "#6366f1" : "rgba(148, 163, 184, 0.5)",
+      backgroundColor: "rgba(31, 31, 61, 0.85)",
+      borderColor: state.isFocused
+        ? "#6366f1"
+        : "rgba(148, 163, 184, 0.35)",
       boxShadow: state.isFocused
-        ? "0 0 0 4px rgba(99, 102, 241, 0.15)"
+        ? "0 0 0 4px rgba(99, 102, 241, 0.2)"
         : "none",
       borderRadius: 12,
       minHeight: "48px",
@@ -102,32 +104,35 @@ function IssueRegister() {
     }),
     option: (provided: any, state: any) => ({
       ...provided,
-      backgroundColor: state.isFocused ? "rgba(99, 102, 241, 0.08)" : "#fff",
-      color: "#1f2937",
+      backgroundColor: state.isFocused
+        ? "rgba(99, 102, 241, 0.22)"
+        : "rgba(31, 31, 61, 0.98)",
+      color: "#f8fafc",
       padding: "10px 14px",
       fontSize: "14px",
       cursor: "pointer",
     }),
     singleValue: (provided: any) => ({
       ...provided,
-      color: "#1f2937",
+      color: "#f8fafc",
       fontWeight: 600,
     }),
     placeholder: (provided: any) => ({
       ...provided,
-      color: "#9ca3af",
+      color: "#cbd5f5",
       fontSize: "14px",
     }),
     menu: (provided: any) => ({
       ...provided,
       borderRadius: 12,
-      boxShadow: "0 18px 32px rgba(15, 23, 42, 0.12)",
+      backgroundColor: "rgba(31, 31, 61, 0.98)",
+      boxShadow: "0 18px 32px rgba(4, 6, 28, 0.35)",
       zIndex: 6,
       overflow: "hidden",
     }),
     input: (provided: any) => ({
       ...provided,
-      color: "#1f2937",
+      color: "#f8fafc",
     }),
   };
 


### PR DESCRIPTION
## Summary
- restyle the issue registration layout to reuse the dark palette from the login screen
- update inputs, badges, and helper text to remain legible on the darker surface
- adjust the react-select styling so dropdowns match the refreshed theme

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69037973f9108326972499a6dff38287